### PR TITLE
Safari selection fix

### DIFF
--- a/components/Art/Art.css
+++ b/components/Art/Art.css
@@ -30,3 +30,8 @@
   opacity: 0;
   -webkit-transform: translateY(50px);
 }
+
+textarea{
+  font-size: 16px;
+  border: none;
+}

--- a/components/Art/Art.css
+++ b/components/Art/Art.css
@@ -24,6 +24,10 @@
   font-size: 16px;
   border: none;
   resize: none;
+  letter-spacing: -4px;
+  text-rendering: geometricPrecision;
+  width: 200px;
+  text-align: center;
 }
 
 .Art[hidden] {

--- a/components/Art/Art.js
+++ b/components/Art/Art.js
@@ -71,12 +71,9 @@ class Art extends React.Component {
       });
     }
 
-    console.log(art);
-
     return (
-      <div id="art" hidden={this.props.phrase === ''} className="Art" ref="textarea">
-      	{art.map((i, idx) => <span key={idx}>{i}</span>)}
-      </div>
+		<textarea value={art.join('')} id="art" hidden={this.props.phrase === ''} className="Art" ref="textarea">
+		</textarea>
     );
   }
 }

--- a/components/Copy/Copy.js
+++ b/components/Copy/Copy.js
@@ -24,7 +24,9 @@ class Copy extends React.Component {
     });
 
     clipboard.on('error', function(e) {
-        //TODO show info for Safari?
+        //Safari
+        var ele = document.getElementById('art');
+        ele && ele.select();
     });
   }
 
@@ -58,8 +60,6 @@ class Copy extends React.Component {
   }
 
   render() {
-    new Clipboard('#copy');
-
     return (
       <div className="Copy" hidden={this.props.phrase === ''}>
         <button className="select-btn" type="button" id="copy" data-clipboard-target="#art">


### PR DESCRIPTION
This uses textarea as workaround. Need to text but I should work. Side effect is that Safari selects entire area (looks weird) including whitespace. Chrome seems to behave correctly.
